### PR TITLE
Update broken functionality

### DIFF
--- a/eid/models_test.go
+++ b/eid/models_test.go
@@ -1,6 +1,7 @@
 package eid
 
 import (
+	"context"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func diffObj(expected interface{}, got interface{}) string {
 	return fmt.Sprintf("expected:\n%s\ngot:\n%s\n", strings.Join(e, "\n"), strings.Join(g, "\n"))
 }
 
+var testClient = &TestClient{}
 var fromGrpcInterTests = []struct {
 	in  *twoferrpc.Inter
 	err string
@@ -46,7 +48,7 @@ var fromGrpcInterTests = []struct {
 		err: "",
 		res: Inter{
 			Req: &Req{
-				Provider: nil,
+				Provider: testClient,
 				Who:      &User{},
 				Payload:  nil,
 			},
@@ -63,7 +65,8 @@ var fromGrpcInterTests = []struct {
 		err: "",
 		res: Inter{
 			Req: &Req{
-				Who: &User{},
+				Provider: testClient,
+				Who:      &User{},
 			},
 			Mode: SIGN,
 		},
@@ -78,7 +81,8 @@ var fromGrpcInterTests = []struct {
 		err: "",
 		res: Inter{
 			Req: &Req{
-				Who: &User{},
+				Provider: testClient,
+				Who:      &User{},
 			},
 			Mode: AUTH,
 		},
@@ -86,9 +90,8 @@ var fromGrpcInterTests = []struct {
 }
 
 func TestFromGrpcInter(t *testing.T) {
-
 	for _, test := range fromGrpcInterTests {
-		i, err := FromGrpcInter(test.in)
+		i, err := FromGrpcInter(test.in, testClient)
 
 		if test.err != "" {
 			assert.EqualError(t, err, test.err)
@@ -100,4 +103,28 @@ func TestFromGrpcInter(t *testing.T) {
 		}
 	}
 
+}
+
+type TestClient struct {
+}
+
+func (c *TestClient) Name() (s string) {
+	return "wat"
+}
+
+func (c *TestClient) AuthInit(ctx context.Context, req *Req) (*Inter, error) {
+	return &Inter{}, nil
+}
+func (c *TestClient) SignInit(ctx context.Context, req *Req) (*Inter, error) {
+	return &Inter{}, nil
+}
+
+func (c *TestClient) Peek(ctx context.Context, req *Inter) (*Resp, error) {
+	return &Resp{}, nil
+}
+func (c *TestClient) Collect(ctx context.Context, req *Inter, cancelOnErr bool) (*Resp, error) {
+	return &Resp{}, nil
+}
+func (c *TestClient) Cancel(intermediate *Inter) error {
+	return nil
 }

--- a/internal/eidserver/server.go
+++ b/internal/eidserver/server.go
@@ -35,7 +35,7 @@ func (s Server) AuthInit(ctx context.Context, req *twoferrpc.Req) (in *twoferrpc
 	if err != nil {
 		return
 	}
-	eidReq, err := eid.FromGrpcReq(req)
+	eidReq, err := eid.FromGrpcReq(req, cli)
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ func (s Server) AuthInit(ctx context.Context, req *twoferrpc.Req) (in *twoferrpc
 	if err != nil {
 		return
 	}
-	grpcInter, err := eid.ToGrpcInter(authInit, req.Provider.Name)
+	grpcInter, err := eid.ToGrpcInter(authInit)
 	if err != nil {
 		return
 	}
@@ -57,17 +57,15 @@ func (s Server) SignInit(ctx context.Context, req *twoferrpc.Req) (in *twoferrpc
 		return
 	}
 	fmt.Printf("Using provider %s to do sign request\n", cli.Name())
-	eidReq, err := eid.FromGrpcReq(req)
+	eidReq, err := eid.FromGrpcReq(req, cli)
 	if err != nil {
 		return
 	}
-	fmt.Printf("EIDRequest%+v\n", eidReq)
 	signInit, err := cli.SignInit(ctx, &eidReq)
 	if err != nil {
 		return
 	}
-	fmt.Printf("Sign Init: %+v\n", signInit)
-	grpcInter, err := eid.ToGrpcInter(signInit, req.Provider.Name)
+	grpcInter, err := eid.ToGrpcInter(signInit)
 	if err != nil {
 		return
 	}
@@ -79,7 +77,7 @@ func (s Server) Collect(ctx context.Context, inter *twoferrpc.Inter) (r *twoferr
 	if err != nil {
 		return
 	}
-	eidInter, err := eid.FromGrpcInter(inter)
+	eidInter, err := eid.FromGrpcInter(inter, cli)
 	if err != nil {
 		return
 	}
@@ -99,15 +97,15 @@ func (s Server) Peek(ctx context.Context, inter *twoferrpc.Inter) (res *twoferrp
 	if err != nil {
 		return
 	}
-	eidInter, err := eid.FromGrpcInter(inter)
+	eidInter, err := eid.FromGrpcInter(inter, cli)
 	if err != nil {
 		return
 	}
-	collect, err := cli.Peek(ctx, &eidInter)
+	peek, err := cli.Peek(ctx, &eidInter)
 	if err != nil {
 		return
 	}
-	grpcRes, err := eid.ToGrpcResp(collect)
+	grpcRes, err := eid.ToGrpcResp(peek)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- Some mappings gave nil dereferencing, not good.
- Send in client to all FromGrpc translations. Reason is we want to be
able to pass that back when going back to grpc