### PR TITLE
V3 API: Rework twofer API to avoid calling 'collect' from the auth and sign methods

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -42,6 +42,10 @@ type (
 		// EndUserIp The user IP address as it is seen by your service
 		EndUserIp string `json:"endUserIp"`
 
+		// ReturnUrl Orders started on the same device as where the user's BankID is stored (started with autostart
+		// token) will call this URL when the order is completed
+		ReturnUrl string `json:"returnUrl,omitempty"`
+
 		// UserNonVisibleData Data that you wish to include but not display to the user
 		UserNonVisibleData string `json:"userNonVisibleData,omitempty"`
 

--- a/api/models.go
+++ b/api/models.go
@@ -1,32 +1,8 @@
 package api
 
 type (
-	BankIdv6AuthSignRequest struct {
-		EndUserIp             string                      `json:"endUserIp"`
-		Requirement           BankIdv6AuthSignRequirement `json:"requirement,omitempty"`
-		UserVisibleData       string                      `json:"userVisibleData,omitempty"`
-		UserNonVisibleData    string                      `json:"userNonVisibleData,omitempty"`
-		UserVisibleDataFormat string                      `json:"userVisibleDataFormat,omitempty"`
-	}
-	BankIdv6AuthSignRequirement struct {
-		PinCode             bool     `json:"pinCode,omitempty"`
-		MRTD                bool     `json:"mrtd,omitempty"`
-		CardReader          string   `json:"cardReader,omitempty"`
-		CertificatePolicies []string `json:"certificatePolicies,omitempty"`
-		PersonalNumber      string   `json:"personalNumber,omitempty"`
-	}
-	BankIdv6ChangeRequest struct {
-		OrderRef string `json:"orderRef"`
-
-		// WaitUntilFinished allows the request to wait until the referenced request has either completed or failed,
-		// and will not return on state changes during the ongoing process.
-		WaitUntilFinished bool `json:"onFinished"`
-	}
-
-	BankIdv6CollectRequest struct {
-		OrderRef string `json:"orderRef"`
-	}
-
+	// BankIdV6Response used as a catch all response for V2
+	// Deprecated: stick to V1 or move to V3
 	BankIdV6Response struct {
 		OrderRef       string                  `json:"orderRef"`
 		ErrorCode      string                  `json:"errorCode,omitempty"`
@@ -58,12 +34,109 @@ type (
 	BankIdV6StepUp struct {
 		MRTD bool `json:"mrtd,omitempty"`
 	}
+
+	// V3 request / response messages
+
+	// BankIdv6AuthSignRequestV3 is used to start either an auth or sign request against BankID
+	BankIdv6AuthSignRequestV3 struct {
+		// EndUserIp The user IP address as it is seen by your service
+		EndUserIp string `json:"endUserIp"`
+
+		// UserNonVisibleData Data that you wish to include but not display to the user
+		UserNonVisibleData string `json:"userNonVisibleData,omitempty"`
+
+		// UserVisibleData Text displayed to the user during the order
+		UserVisibleData string `json:"userVisibleData,omitempty"`
+
+		// UserVisibleDataFormat, 'plaintext' or 'simpleMarkdownV1'
+		UserVisibleDataFormat string `json:"userVisibleDataFormat,omitempty"`
+
+		// PersonalNumber The personal identity number allowed to confirm the identification
+		PersonalNumber string `json:"personalNumber,omitempty"`
+
+		// PinCode User is required to confirm the order with their security code even if they have biometrics activated
+		PinCode bool `json:"pinCode,omitempty"`
+
+		// Once if true, will start an auth/sign and just return a single QR code, if false, auth/sign endpoint return
+		// an SSE / NDJSON stream and send a new QR-code each second, for 30 seconds before returning
+		Once bool `json:"once,omitempty"`
+	}
+
+	// BankIdV6AuthSignResponseV3 is sent as a successful reply to an auth or sign request. If SSE / NDJSON is used, a
+	// new BankIdV6AuthSignResponseV3 is sent each second (for 30 seconds)
+	BankIdV6AuthSignResponseV3 struct {
+		// OrderRef The reference ID for an order
+		OrderRef string `json:"orderRef"`
+
+		// URI Start URL, for "BankID on this device"
+		URI string `json:"uri"`
+
+		// QR contain the data for the QR-code
+		QR string `json:"qr"`
+	}
+
+	// BankIdv6CollectRequestV3 is used to collect status on a started auth / sign request
+	BankIdv6CollectRequestV3 struct {
+		// OrderRef A reference ID for an order
+		OrderRef string `json:"orderRef"`
+
+		// WaitForChange allows the request to wait until a change is detected
+		WaitForChange bool `json:"waitForChange"`
+
+		// WaitUntilFinished allows the request to wait until the referenced request has either completed or failed,
+		// and will not return on state changes during the ongoing process.
+		WaitUntilFinished bool `json:"waitUntilFinished"`
+	}
+
+	// BankIdV6CollectResponseV3 is sent for a successful collect, if WaitUntilFinished is set in the request, it will
+	// only return once the order have either completed or failed. If WaitUntilFinished isn't set, it will return once
+	// a change is detected.
+	BankIdV6CollectResponseV3 struct {
+		// OrderRef The reference ID for an order
+		OrderRef       string                  `json:"orderRef"`
+		Status         string                  `json:"status,omitempty"`
+		HintCode       string                  `json:"hintCode,omitempty"`
+		CompletionData *BankIdV6CompletionData `json:"completionData,omitempty"`
+	}
+
+	// BankIdv6CancelRequestV3 request the cancellation of a pending auth / sign request
+	BankIdv6CancelRequestV3 struct {
+		// OrderRef A reference ID for an order
+		OrderRef string `json:"orderRef"`
+	}
+
+	BankIdv6CancelResponseV3 struct {
+		Status string `json:"status"`
+	}
+
+	// BankIdv6ErrorResponseV3 is sent when an endpoint return an error (4xx, 5xx) http status code
+	BankIdv6ErrorResponseV3 struct {
+		// Origin contains the origin of the error, currently either 'Twofer' or 'BankIDv6'
+		Origin string `json:"origin"` // Twofer / BankIDv6
+
+		// StatusCode contain the original HTTP status code, if the error originates from BankID
+		StatusCode int `json:"statusCode,omitempty"`
+
+		// ErrorCode contain the original error code that we may get from BankID when they return an http 400
+		Code string `json:"code,omitempty"`
+
+		// Detail may contain the original error detail that we may get from BankID when they return an http 400, or it
+		// can be an error message generated in twofer, for twofer errors
+		Detail string `json:"detail"`
+	}
 )
 
+// Status codes
 const (
 	StatusPending  = "pending"
 	StatusComplete = "complete"
 	StatusFailed   = "failed"
 	StatusError    = "error"
 	StatusQrCode   = "qrcode"
+)
+
+// Error origin codes
+const (
+	ErrorOriginTwofer   = "Twofer"
+	ErrorOriginBankIDv6 = "BankIDv6"
 )

--- a/api/models.go
+++ b/api/models.go
@@ -1,6 +1,32 @@
 package api
 
 type (
+	BankIdv6AuthSignRequest struct {
+		EndUserIp             string                      `json:"endUserIp"`
+		Requirement           BankIdv6AuthSignRequirement `json:"requirement,omitempty"`
+		UserVisibleData       string                      `json:"userVisibleData,omitempty"`
+		UserNonVisibleData    string                      `json:"userNonVisibleData,omitempty"`
+		UserVisibleDataFormat string                      `json:"userVisibleDataFormat,omitempty"`
+	}
+	BankIdv6AuthSignRequirement struct {
+		PinCode             bool     `json:"pinCode,omitempty"`
+		MRTD                bool     `json:"mrtd,omitempty"`
+		CardReader          string   `json:"cardReader,omitempty"`
+		CertificatePolicies []string `json:"certificatePolicies,omitempty"`
+		PersonalNumber      string   `json:"personalNumber,omitempty"`
+	}
+	BankIdv6ChangeRequest struct {
+		OrderRef string `json:"orderRef"`
+
+		// WaitUntilFinished allows the request to wait until the referenced request has either completed or failed,
+		// and will not return on state changes during the ongoing process.
+		WaitUntilFinished bool `json:"onFinished"`
+	}
+
+	BankIdv6CollectRequest struct {
+		OrderRef string `json:"orderRef"`
+	}
+
 	BankIdV6Response struct {
 		OrderRef       string                  `json:"orderRef"`
 		ErrorCode      string                  `json:"errorCode,omitempty"`
@@ -39,4 +65,5 @@ const (
 	StatusComplete = "complete"
 	StatusFailed   = "failed"
 	StatusError    = "error"
+	StatusQrCode   = "qrcode"
 )

--- a/cmd/twoferd/main.go
+++ b/cmd/twoferd/main.go
@@ -146,6 +146,7 @@ func startEid(e *echo.Echo) {
 		PemRootCA:     config.Get().BankID.GetRootCA(),
 		PemClientCert: config.Get().BankID.GetClientCert(),
 		PemClientKey:  config.Get().BankID.GetClientKey(),
+		PollInterval:  config.Get().BankID.PollInterval,
 	})
 	if err != nil {
 		fmt.Printf("failed to initate bankId %v", err)

--- a/internal/bankid/bankid_models.go
+++ b/internal/bankid/bankid_models.go
@@ -200,12 +200,13 @@ func (c *CancelRequest) Validate() error {
 }
 
 type BankIdError struct {
-	ErrorCode string `json:"errorCode"`
-	Details   string `json:"details"`
+	StatusCode int    `json:"-"`
+	ErrorCode  string `json:"errorCode"`
+	Details    string `json:"details"`
 }
 
 func (e BankIdError) Error() string {
-	return fmt.Sprintf("bankid: %s, %s", e.ErrorCode, e.Details)
+	return fmt.Sprintf("bankid: (%d) %s, %s", e.StatusCode, e.ErrorCode, e.Details)
 }
 
 type Empty struct{}

--- a/internal/bankid/endpoints.go
+++ b/internal/bankid/endpoints.go
@@ -19,14 +19,16 @@ const (
 )
 
 type API struct {
-	baseURL string
-	client  *http.Client
+	baseURL      string
+	client       *http.Client
+	pollInterval time.Duration
 }
 
-func NewAPI(client *http.Client, baseURL string) *API {
+func NewAPI(client *http.Client, baseURL string, pollInterval time.Duration) *API {
 	return &API{
-		client:  client,
-		baseURL: baseURL,
+		client:       client,
+		baseURL:      baseURL,
+		pollInterval: pollInterval,
 	}
 }
 
@@ -94,7 +96,7 @@ func (a *API) Change(ctx context.Context, r *ChangeRequest) (*CollectResponse, e
 		case <-ctx.Done():
 			err = ctx.Err()
 			return nil, err
-		case <-time.After(time.Second):
+		case <-time.After(a.pollInterval):
 		}
 
 		var resp *CollectResponse

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	WebAuthn  WebAuthn
 	PWD       PWD
 
-	StreamEncoder string `env:"STREAM_ENCODER" envDefault:"NDJSON"`
+	StreamEncoder string `env:"STREAM_ENCODER" envDefault:"SSE"`
 }
 
 func (c Config) EIDEnabled() bool {
@@ -36,14 +36,15 @@ type OTP struct {
 }
 
 type BankID struct {
-	Enabled        bool     `env:"EID_BANKID_ENABLE" envDefault:"FALSE"`
-	URL            *url.URL `env:"EID_BANKID_URL"`
-	RootCA         string   `env:"EID_BANKID_ROOT_CA_PEM"`
-	RootCAFile     string   `env:"EID_BANKID_ROOT_CA_PEM_FILE,file"`
-	ClientCert     string   `env:"EID_BANKID_CLIENT_CERT"`
-	ClientCertFile string   `env:"EID_BANKID_CLIENT_CERT_FILE,file"`
-	ClientKey      string   `env:"EID_BANKID_CLIENT_KEY"`
-	ClientKeyFile  string   `env:"EID_BANKID_CLIENT_KEY_FILE,file"`
+	Enabled        bool          `env:"EID_BANKID_ENABLE" envDefault:"FALSE"`
+	URL            *url.URL      `env:"EID_BANKID_URL"`
+	RootCA         string        `env:"EID_BANKID_ROOT_CA_PEM"`
+	RootCAFile     string        `env:"EID_BANKID_ROOT_CA_PEM_FILE,file"`
+	ClientCert     string        `env:"EID_BANKID_CLIENT_CERT"`
+	ClientCertFile string        `env:"EID_BANKID_CLIENT_CERT_FILE,file"`
+	ClientKey      string        `env:"EID_BANKID_CLIENT_KEY"`
+	ClientKeyFile  string        `env:"EID_BANKID_CLIENT_KEY_FILE,file"`
+	PollInterval   time.Duration `env:"EID_BANKID_POLL_INTERVAL" envDefault:"2s"` // Poll BankID every two seconds as default (according to their spec)
 }
 
 func (b BankID) GetRootCA() []byte {

--- a/internal/eid/bankid/bankid.go
+++ b/internal/eid/bankid/bankid.go
@@ -8,6 +8,7 @@ import (
 	bankid_v51 "github.com/modfin/twofer/internal/eid/bankid/v5.1"
 	"github.com/modfin/twofer/internal/mtls"
 	"net/http"
+	"time"
 )
 
 type ClientConfig struct {
@@ -16,6 +17,8 @@ type ClientConfig struct {
 	PemRootCA     []byte
 	PemClientCert []byte
 	PemClientKey  []byte
+
+	PollInterval time.Duration
 }
 
 func New(config ClientConfig) (client *BankID, err error) {
@@ -47,7 +50,7 @@ func New(config ClientConfig) (client *BankID, err error) {
 
 	client.APIv51 = bankid_v51.NewEid(client.httpClient, config.BaseURL)
 
-	client.APIv60 = bankid.NewAPI(client.httpClient, client.baseURL)
+	client.APIv60 = bankid.NewAPI(client.httpClient, client.baseURL, config.PollInterval)
 
 	return
 }

--- a/internal/httpserve/bankid.go
+++ b/internal/httpserve/bankid.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-
 	"github.com/modfin/twofer/api"
 	"github.com/modfin/twofer/internal/bankid"
 	"github.com/modfin/twofer/internal/sse"
@@ -30,10 +29,10 @@ func RegisterBankIDServer(e *echo.Echo, client *bankid.API, newEncoder NewStream
 	e.POST("/bankid/v6/signv2", authSign(client.Sign, client.WatchForChangeV2, qrCodeUpdatePeriod, newEncoder)) // Deprecated: Don't use
 	e.POST("/bankid/v6/signv3", authSignV3(client.Sign, qrCodeUpdatePeriod, newEncoder))                        // Same as 'sign' except won't poll BankID collect API (since a completed/failed orderRef can only be collected once)
 	e.POST("/bankid/v6/change", change(client))
-	e.POST("/bankid/v6/changeV3", changeV3(client))
 	e.POST("/bankid/v6/collect", collect(client))
 	e.POST("/bankid/v6/collectV3", collectV3(client))
 	e.POST("/bankid/v6/cancel", cancel(client))
+	e.POST("/bankid/v6/cancelV3", cancelV3(client))
 }
 
 func auth(client *bankid.API) func(echo.Context) error {
@@ -122,7 +121,6 @@ func auth(client *bankid.API) func(echo.Context) error {
 }
 
 func sign(client *bankid.API) func(echo.Context) error {
-	// TODO: Refactor auth and sign into single function that can handle both since the code if pretty much identical?
 	return func(e echo.Context) error {
 		b, err := io.ReadAll(e.Request().Body)
 		if err != nil {
@@ -281,6 +279,7 @@ func cancel(client *bankid.API) func(echo.Context) error {
 	}
 }
 
+// Deprecated V2 API, stick to V1 or switch to V3
 func createResponseFromAuthSign(r *bankid.AuthSignResponse, qrCodeTime int) api.BankIdV6Response {
 	return api.BankIdV6Response{
 		OrderRef: r.OrderRef,
@@ -289,6 +288,7 @@ func createResponseFromAuthSign(r *bankid.AuthSignResponse, qrCodeTime int) api.
 	}
 }
 
+// Deprecated V2 API, stick to V1 or switch to V3
 func createResponseFromCollect(change bankid.Change) api.BankIdV6Response {
 	// Status == pending, only send status and hint updates
 	if change.Status == bankid.Pending {
@@ -315,6 +315,7 @@ func createResponseFromCollect(change bankid.Change) api.BankIdV6Response {
 	}
 }
 
+// Deprecated V2 API, stick to V1 or switch to V3
 func createResponseFromError(orderRef string, err error) api.BankIdV6Response {
 	var bie bankid.BankIdError
 	if errors.As(err, &bie) {
@@ -343,7 +344,7 @@ const (
 	errorEvent  = "error"
 )
 
-// Deprecated: Use either /bankid/v6/auth or /bankid/v6/authv3 endpoints
+// Deprecated: V2 API, use either /bankid/v6/auth or /bankid/v6/authv3 endpoints
 func authSign(authSign authSignFn, watch watchFn, qrPeriod time.Duration, newStreamEncoder NewStreamEncoder) func(echo.Context) error {
 	return func(c echo.Context) error {
 		b, err := io.ReadAll(c.Request().Body)
@@ -459,90 +460,26 @@ func readBody[T any](body io.ReadCloser) (*T, error) {
 	return &request, nil
 }
 
-func errToBankIdV6Response(orderRef string, err error) api.BankIdV6Response {
+func bankIdv6ErrorResponseV3(err error, detail string) api.BankIdv6ErrorResponseV3 {
 	if err != nil {
 		var bie bankid.BankIdError
 		if errors.As(err, &bie) {
-			return api.BankIdV6Response{
-				OrderRef:  orderRef,
-				Status:    api.StatusError,
-				ErrorCode: bie.ErrorCode,
-				ErrorText: bie.Details,
+			return api.BankIdv6ErrorResponseV3{
+				Origin:     api.ErrorOriginBankIDv6,
+				StatusCode: bie.StatusCode,
+				Code:       bie.ErrorCode,
+				Detail:     bie.Details,
 			}
 		}
-		return api.BankIdV6Response{
-			OrderRef:  orderRef,
-			Status:    api.StatusError,
-			ErrorText: err.Error(),
+		return api.BankIdv6ErrorResponseV3{
+			Origin: api.ErrorOriginTwofer,
+			Code:   err.Error(),
+			Detail: detail,
 		}
 	}
-
-	return api.BankIdV6Response{OrderRef: orderRef, Status: api.StatusError, ErrorText: "no error"}
-}
-
-func authSignToBankIdV6Response(orderRef string, asr *bankid.AuthSignResponse, qrNo int) api.BankIdV6Response {
-	if asr == nil {
-		return api.BankIdV6Response{
-			OrderRef:  orderRef,
-			Status:    api.StatusError,
-			ErrorText: "no auth/sign data",
-		}
-	}
-
-	return api.BankIdV6Response{
-		OrderRef: orderRef,
-		Status:   api.StatusQrCode,
-		URI:      fmt.Sprintf("bankid:///?autostarttoken=%s&redirect=null", asr.AutoStartToken),
-		QR:       asr.BuildQrCode(qrNo),
-	}
-}
-
-func collectToBankIdV6Response(orderRef string, collectResponse *bankid.CollectResponse) api.BankIdV6Response {
-	if collectResponse == nil {
-		return api.BankIdV6Response{
-			OrderRef:  orderRef,
-			Status:    api.StatusError,
-			ErrorText: "no collect data",
-		}
-	}
-
-	switch collectResponse.Status {
-	// Status == pending, only send status and hint updates
-	case bankid.Pending:
-		return api.BankIdV6Response{
-			OrderRef: orderRef,
-			Status:   api.StatusPending,
-			HintCode: string(collectResponse.HintCode),
-		}
-	// Status == failed, only send status and hint updates
-	case bankid.Failed:
-		return api.BankIdV6Response{
-			OrderRef: orderRef,
-			Status:   api.StatusFailed,
-			HintCode: string(collectResponse.HintCode),
-		}
-	// Status == complete, send complete message
-	case bankid.Complete:
-		return api.BankIdV6Response{
-			OrderRef: orderRef,
-			Status:   api.StatusComplete,
-			HintCode: string(collectResponse.HintCode),
-			CompletionData: &api.BankIdV6CompletionData{
-				User:            api.BankIdV6User(collectResponse.CompletionData.User),
-				Device:          api.BankIdV6Device(collectResponse.CompletionData.Device),
-				BankIdIssueDate: collectResponse.CompletionData.BankIdIssueDate,
-				StepUp:          api.BankIdV6StepUp(collectResponse.CompletionData.StepUp),
-				Signature:       collectResponse.CompletionData.Signature,
-				OcspResponse:    collectResponse.CompletionData.OcspResponse,
-			},
-		}
-	// Unknown status
-	default:
-		return api.BankIdV6Response{OrderRef: orderRef,
-			Status:    api.StatusError,
-			HintCode:  string(collectResponse.HintCode),
-			ErrorText: fmt.Sprintf("unknown collect response status: %v", collectResponse.Status),
-		}
+	return api.BankIdv6ErrorResponseV3{
+		Origin: api.ErrorOriginTwofer,
+		Detail: detail,
 	}
 }
 
@@ -550,20 +487,25 @@ func collectToBankIdV6Response(orderRef string, collectResponse *bankid.CollectR
 // The biggest difference is that it won't call the BankID collect API to watch for changes, since
 // a completed/failed orderRef can only be collected once, so this endpoint will continue to send
 // QR-codes for 30 seconds. All status updates must be handled outside twofer, by calling collect
-// or change endpoints after the first QR-code has been returned. This also always returns one or
-// more api.BankIdV6Response structs
+// or change endpoints after the first QR-code has been returned. It also returns one or more
+// api.BankIdV6AuthSignResponseV3 structs for a successful auth/sign request. For failed requests,
+// a api.BankIdv6ErrorResponseV3 is returned instead.
 func authSignV3(authOrSignFn authSignFn, qrPeriod time.Duration, newStreamEncoder NewStreamEncoder) func(echo.Context) error {
 	return func(c echo.Context) error {
-		request, err := readBody[api.BankIdv6AuthSignRequest](c.Request().Body)
+		request, err := readBody[api.BankIdv6AuthSignRequestV3](c.Request().Body)
 		if err != nil {
-			fmt.Printf("ERR: failed to unmarshal auth request message: %v\n", err)
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response("", err))
+			fmt.Printf("ERR: read request body error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "read request body error"))
 		}
 
 		// Convert from public API to internal struct
+		br := bankid.Requirement{
+			PinCode:        request.PinCode,
+			PersonalNumber: request.PersonalNumber,
+		}
 		r := &bankid.AuthSignRequest{
 			EndUserIp:             request.EndUserIp,
-			Requirement:           bankid.Requirement(request.Requirement),
+			Requirement:           br,
 			UserVisibleData:       request.UserVisibleData,
 			UserNonVisibleData:    request.UserNonVisibleData,
 			UserVisibleDataFormat: request.UserVisibleDataFormat,
@@ -571,30 +513,37 @@ func authSignV3(authOrSignFn authSignFn, qrPeriod time.Duration, newStreamEncode
 
 		res, err := authOrSignFn(c.Request().Context(), r)
 		if err != nil {
-			fmt.Printf("ERR: initiating auth/sign request against bankid: %v\n", err)
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response("", err))
+			fmt.Printf("ERR: auth/sign request error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "auth/sign request error"))
+		}
+
+		bankIdV6AuthSignResponseV3 := func(r *bankid.AuthSignResponse, qrNo int) api.BankIdV6AuthSignResponseV3 {
+			return api.BankIdV6AuthSignResponseV3{
+				OrderRef: r.OrderRef,
+				URI:      fmt.Sprintf("bankid:///?autostarttoken=%s&redirect=null", r.AutoStartToken),
+				QR:       r.BuildQrCode(qrNo),
+			}
 		}
 
 		// In the case a client wants to initiate a new request every second instead of relying on SSE
 		// we respond with the first entry and then close the connection
-		response := c.QueryParam("type")
-		if response == "once" {
-			return c.JSON(http.StatusOK, authSignToBankIdV6Response(res.OrderRef, res, 0))
+		if request.Once {
+			return c.JSON(http.StatusOK, bankIdV6AuthSignResponseV3(res, 0))
 		}
 
 		// Create SSE / NDJSON event stream
 		send, err := newStreamEncoder(c.Response())
 		if err != nil {
-			fmt.Printf("ERR: failed to setup auth response stream: %s\n", err.Error())
-			return c.JSON(http.StatusInternalServerError, errToBankIdV6Response(res.OrderRef, err))
+			fmt.Printf("ERR: failed to setup response stream: %v\n", err)
+			return c.JSON(http.StatusInternalServerError, bankIdv6ErrorResponseV3(err, "failed to setup response stream"))
 		}
 
 		// Stream new QR codes for about 30 seconds
 		for i := 0; i < 30; i++ {
-			err = send(strconv.Itoa(i), "message", authSignToBankIdV6Response(res.OrderRef, res, i))
+			err = send(strconv.Itoa(i), "message", bankIdV6AuthSignResponseV3(res, i))
 			if err != nil {
-				fmt.Printf("ERR: failed to send QR-code message: %s\n", err.Error())
-				return c.JSON(http.StatusInternalServerError, "failed to send response message")
+				fmt.Printf("ERR: failed to send QR-code message: %v\n", err)
+				return c.JSON(http.StatusInternalServerError, bankIdv6ErrorResponseV3(err, "failed to send response message"))
 			}
 			time.Sleep(qrPeriod)
 		}
@@ -602,46 +551,65 @@ func authSignV3(authOrSignFn authSignFn, qrPeriod time.Duration, newStreamEncode
 	}
 }
 
-// Pretty much the same as change, except that we always return the twofer public api.BankIdV6Response struct
-func changeV3(client *bankid.API) func(echo.Context) error {
+// Pretty much the same as collect and change, except that it will return an api.BankIdV6CollectResponseV3 struct for
+// successful requests, for failed requests, an api.BankIdv6ErrorResponseV3 is returned instead.
+func collectV3(client *bankid.API) func(echo.Context) error {
 	return func(c echo.Context) error {
-		request, err := readBody[api.BankIdv6ChangeRequest](c.Request().Body)
+		request, err := readBody[api.BankIdv6CollectRequestV3](c.Request().Body)
 		if err != nil {
-			fmt.Printf("ERR: failed to unmarshal change request message: %v\n", err)
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response("", err))
+			fmt.Printf("ERR: read request body error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "read request body error"))
 		}
 
-		// Convert from public API to internal struct
-		r := &bankid.ChangeRequest{
-			OrderRef:          request.OrderRef,
-			WaitUntilFinished: request.WaitUntilFinished,
+		var res *bankid.CollectResponse
+		if request.WaitForChange || request.WaitUntilFinished {
+			res, err = client.ChangeV3(c.Request().Context(), &bankid.ChangeRequest{
+				OrderRef:          request.OrderRef,
+				WaitUntilFinished: request.WaitUntilFinished,
+			})
+		} else {
+			res, err = client.Collect(c.Request().Context(), &bankid.CollectRequest{OrderRef: request.OrderRef})
 		}
-
-		res, err := client.Change(c.Request().Context(), r)
 		if err != nil {
-			fmt.Printf("ERR: initiating change request against bankid: %v\n", err)
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response(request.OrderRef, err))
+			fmt.Printf("ERR: collect request error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "collect request error"))
 		}
 
-		return c.JSON(http.StatusOK, collectToBankIdV6Response(request.OrderRef, res))
+		reply := api.BankIdV6CollectResponseV3{
+			OrderRef: res.OrderRef,
+			Status:   string(res.Status),
+			HintCode: string(res.HintCode),
+		}
+		if res.Status == bankid.Complete {
+			reply.CompletionData = &api.BankIdV6CompletionData{
+				User:            api.BankIdV6User(res.CompletionData.User),
+				Device:          api.BankIdV6Device(res.CompletionData.Device),
+				BankIdIssueDate: res.CompletionData.BankIdIssueDate,
+				StepUp:          api.BankIdV6StepUp(res.CompletionData.StepUp),
+				Signature:       res.CompletionData.Signature,
+				OcspResponse:    res.CompletionData.OcspResponse,
+			}
+		}
+		return c.JSON(http.StatusOK, reply)
 	}
 }
 
-// Pretty much the same as collect, except that we always return the twofer public api.BankIdV6Response struct
-func collectV3(client *bankid.API) func(echo.Context) error {
+// Pretty much the same as cancel, except that it will api.BankIdv6CancelResponseV3 struct for a successful request,
+// for failed requests, an api.BankIdv6ErrorResponseV3 is returned instead.
+func cancelV3(client *bankid.API) func(echo.Context) error {
 	return func(c echo.Context) error {
-		request, err := readBody[api.BankIdv6CollectRequest](c.Request().Body)
+		request, err := readBody[api.BankIdv6CancelRequestV3](c.Request().Body)
 		if err != nil {
-			fmt.Printf("ERR: failed to unmarshal collect request message: %s\n", err.Error())
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response("", err))
+			fmt.Printf("ERR: read request body error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "read request body error"))
 		}
 
-		res, err := client.Collect(c.Request().Context(), &bankid.CollectRequest{OrderRef: request.OrderRef})
+		err = client.Cancel(c.Request().Context(), &bankid.CancelRequest{OrderRef: request.OrderRef})
 		if err != nil {
-			fmt.Printf("ERR: initiating collect request against bankid: %s\n", err.Error())
-			return c.JSON(http.StatusBadRequest, errToBankIdV6Response(request.OrderRef, err))
+			fmt.Printf("ERR: cancel request error: %v\n", err)
+			return c.JSON(http.StatusBadRequest, bankIdv6ErrorResponseV3(err, "cancel request error"))
 		}
 
-		return c.JSON(http.StatusOK, collectToBankIdV6Response(request.OrderRef, res))
+		return c.JSON(http.StatusOK, api.BankIdv6CancelResponseV3{Status: api.StatusComplete})
 	}
 }

--- a/internal/httpserve/bankid.go
+++ b/internal/httpserve/bankid.go
@@ -505,6 +505,7 @@ func authSignV3(authOrSignFn authSignFn, qrPeriod time.Duration, newStreamEncode
 		}
 		r := &bankid.AuthSignRequest{
 			EndUserIp:             request.EndUserIp,
+			ReturnUrl:             request.ReturnUrl,
 			Requirement:           br,
 			UserVisibleData:       request.UserVisibleData,
 			UserNonVisibleData:    request.UserNonVisibleData,

--- a/internal/httpserve/bankid_test.go
+++ b/internal/httpserve/bankid_test.go
@@ -32,11 +32,12 @@ const (
 )
 
 type (
-	authSignTestFn  func(*testing.T) authSignFn
-	watchTestFn     func(*testing.T) watchFn
-	newContextFn    func(r *http.Request, w http.ResponseWriter) echo.Context
-	responseCheckFn func(*testing.T, context.Context, io.ReadCloser, authSignTest)
-	authSignTest    struct {
+	authSignTestFn    func(*testing.T) authSignFn
+	watchTestFn       func(*testing.T) watchFn
+	newContextFn      func(r *http.Request, w http.ResponseWriter) echo.Context
+	responseCheckFn   func(*testing.T, context.Context, io.ReadCloser, authSignTest)
+	responseCheckFnV3 func(*testing.T, context.Context, io.ReadCloser, authSignTestV3)
+	authSignTest      struct {
 		name           string
 		encoder        NewStreamEncoder
 		testDecoder    responseCheckFn
@@ -47,6 +48,18 @@ type (
 		wantHTTPStatus int
 		wantEvents     []sse.Event
 		wantResponses  []api.BankIdV6Response
+	}
+	authSignTestV3 struct {
+		name           string
+		encoder        NewStreamEncoder
+		testDecoder    responseCheckFnV3
+		request        api.BankIdv6AuthSignRequestV3
+		params         *url.Values
+		authSign       authSignTestFn
+		watch          watchTestFn
+		wantHTTPStatus int
+		wantEvents     []sse.Event
+		wantResponses  []api.BankIdV6AuthSignResponseV3
 	}
 )
 
@@ -243,7 +256,7 @@ func ndjsonCheck(t *testing.T, ctx context.Context, body io.ReadCloser, tt authS
 	var cnt int
 	for res := range responseChan {
 		//t.Logf("got response: %v", res)
-		if cnt < len(tt.wantEvents) && !reflect.DeepEqual(res, tt.wantResponses[cnt]) {
+		if cnt < len(tt.wantResponses) && !reflect.DeepEqual(res, tt.wantResponses[cnt]) {
 			t.Errorf(" got event: %v\nwant event: %v", res, tt.wantResponses[cnt])
 		}
 		cnt++
@@ -264,4 +277,170 @@ func sseCheck(t *testing.T, ctx context.Context, body io.ReadCloser, tt authSign
 		t.Errorf("got %d events, want %d", cnt, len(tt.wantEvents))
 	}
 
+}
+
+func Test_authSignV3Stream(t *testing.T) {
+	e := echo.New()
+	for _, tt := range []authSignTestV3{
+		{
+			name:        "happy_auth_flow_sse_stream",
+			encoder:     sse.NewEncoder,
+			testDecoder: sseCheckV3,
+			request:     api.BankIdv6AuthSignRequestV3{EndUserIp: testIP},
+			authSign:    authSignTestMock(authResponseOK, nil),
+			watch: watchMock([]bankid.CollectResponse{
+				pendingOutstandingTransaction,
+				pendingUserSign,
+				completeOK,
+			}, nil),
+			wantHTTPStatus: http.StatusOK,
+			wantEvents: []sse.Event{
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.0.dc69358e712458a66a7525beef148ae8526b1c71610eff2c16cdffb4cdac9bf8"}`, ID: "0"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.1.949d559bf23403952a94d103e67743126381eda00f0b3cbddbf7c96b1adcbce2"}`, ID: "1"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.2.a9e5ec59cb4eee4ef4117150abc58fad7a85439a6a96ccbecc3668b41795b3f3"}`, ID: "2"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.3.96077d77699971790b46ee1f04ff1e44fe96b0602c9c51e4ca9c6d031c7c3bb7"}`, ID: "3"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.4.1d9a7e5dd98d08cb393f73c63ce032df0c9433512153ab9fb040b96cd45b1b11"}`, ID: "4"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.5.56a7bb043d51f8c7aa6828689767b412179a727a6d4e9b7e1c15ded30061bd2f"}`, ID: "5"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.6.51e9a2ea531b5ca7334fd8dd050bd592b8d235d6584ea6b251f0eec4d434267b"}`, ID: "6"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.7.e6a7d5c37920aeb22ea554716fde4dcd42665d5d641a41f459cc9cda03472d31"}`, ID: "7"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.8.d4bbdfa6fe217349d4128429c17bb30cb5b1bc79b54128ef0022478951a273d4"}`, ID: "8"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.9.85fc3076b6a1d9ec5ff73014b006035375c8e9dd34bbbaea60c08e931a6eceeb"}`, ID: "9"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.10.2822ca616ce1e64a1c171df69154ebc5adef4011244c867d6ad88a02db178962"}`, ID: "10"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.11.6c7b122b2bca1ce8ff0c6f24ffe52e69c649b2790fe8485d75f38ae05edd256e"}`, ID: "11"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.12.7b2410a2fdbae51a1f3c5c1e223752d3840ea4664444ceb81319f0707d219a3c"}`, ID: "12"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.13.e6a3ed34b582ea3cc4b905fb2f4d3e9e657999cc4d1898ff3f457964a25b899a"}`, ID: "13"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.14.6e97534d44bb9f38d239f707aad95412cec222dd53e57259320e41e990700a0e"}`, ID: "14"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.15.3ebd4094cce9a3f993e86a5f940da8a94b5be8db42e5d5141aa6b60f51c1c2eb"}`, ID: "15"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.16.3de9e9322183ebe9c102b3349565c32ebb5439da9307f0593962974796892599"}`, ID: "16"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.17.03642ea1c1249141a2f5706acf8cabdb474259afab830e4d94fb95a5229bbf6f"}`, ID: "17"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.18.4556427effb48bcb95c0bcb4208df6984a0dd4c360d9ece47e9efc823419333d"}`, ID: "18"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.19.8755fe51cbd0feb281f85f4a4c18a40f1a30d98480c1b3d18ba1fa54a30ce705"}`, ID: "19"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.20.c5f95da618d92fca54d233363f6d89cecfdca389b8dc331d4ea39d1a24ab78b1"}`, ID: "20"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.21.634cc7d85fa5cb3190c58ff3c821a582c71fd4dcbce18e2560e9f83a92d9f2d1"}`, ID: "21"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.22.fdb8c5e87e2680adde2c5903b892b5e979bc4e7ec1aa7274113efd6048614b87"}`, ID: "22"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.23.d5e52872f000c57a7b03cb7306f18641d3498a0943aedce2d9d471973ef50ce1"}`, ID: "23"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.24.4d0ced42119b047b4e2cc5d01cf3f39f1126969c3e0c9b15c09259fd3584446d"}`, ID: "24"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.25.517b8eda4a7a0de9ba6b603a93d1fc1e3b75d943e308fd28cc04d6e4ab5a5487"}`, ID: "25"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.26.2359ce7475a218e1c346e24caf8dc748636fca4dbaba2c2a40813457ee88b949"}`, ID: "26"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.27.438a3e6e4ab4456ba5251d539c449b03d20022a8446729d549e9d0174d497194"}`, ID: "27"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.28.325b0142d18e1b77bb1a7eb694bbc1c7a30391bda91bf25f3e32dd47284f6978"}`, ID: "28"},
+				{Event: "message", Data: `{"orderRef":"131daac9-16c6-4618-beb0-365768f37288","uri":"bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null","qr":"bankid.67df3917-fa0d-44e5-b327-edcc928297f8.29.26049f2bc12d5b43ebe8bf701e7725abf015d2d8347aa04c924b5793ee4a196c"}`, ID: "29"},
+			},
+		},
+		{
+			name:        "happy_auth_flow_ndjson_stream",
+			encoder:     ndjson.NewEncoder,
+			testDecoder: ndjsonCheckV3,
+			request:     api.BankIdv6AuthSignRequestV3{EndUserIp: testIP},
+			authSign:    authSignTestMock(authResponseOK, nil),
+			watch: watchMock([]bankid.CollectResponse{
+				pendingOutstandingTransaction,
+				pendingUserSign,
+				completeOK,
+			}, nil),
+			wantHTTPStatus: http.StatusOK,
+			wantResponses: []api.BankIdV6AuthSignResponseV3{
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.0.dc69358e712458a66a7525beef148ae8526b1c71610eff2c16cdffb4cdac9bf8"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.1.949d559bf23403952a94d103e67743126381eda00f0b3cbddbf7c96b1adcbce2"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.2.a9e5ec59cb4eee4ef4117150abc58fad7a85439a6a96ccbecc3668b41795b3f3"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.3.96077d77699971790b46ee1f04ff1e44fe96b0602c9c51e4ca9c6d031c7c3bb7"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.4.1d9a7e5dd98d08cb393f73c63ce032df0c9433512153ab9fb040b96cd45b1b11"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.5.56a7bb043d51f8c7aa6828689767b412179a727a6d4e9b7e1c15ded30061bd2f"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.6.51e9a2ea531b5ca7334fd8dd050bd592b8d235d6584ea6b251f0eec4d434267b"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.7.e6a7d5c37920aeb22ea554716fde4dcd42665d5d641a41f459cc9cda03472d31"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.8.d4bbdfa6fe217349d4128429c17bb30cb5b1bc79b54128ef0022478951a273d4"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.9.85fc3076b6a1d9ec5ff73014b006035375c8e9dd34bbbaea60c08e931a6eceeb"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.10.2822ca616ce1e64a1c171df69154ebc5adef4011244c867d6ad88a02db178962"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.11.6c7b122b2bca1ce8ff0c6f24ffe52e69c649b2790fe8485d75f38ae05edd256e"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.12.7b2410a2fdbae51a1f3c5c1e223752d3840ea4664444ceb81319f0707d219a3c"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.13.e6a3ed34b582ea3cc4b905fb2f4d3e9e657999cc4d1898ff3f457964a25b899a"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.14.6e97534d44bb9f38d239f707aad95412cec222dd53e57259320e41e990700a0e"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.15.3ebd4094cce9a3f993e86a5f940da8a94b5be8db42e5d5141aa6b60f51c1c2eb"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.16.3de9e9322183ebe9c102b3349565c32ebb5439da9307f0593962974796892599"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.17.03642ea1c1249141a2f5706acf8cabdb474259afab830e4d94fb95a5229bbf6f"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.18.4556427effb48bcb95c0bcb4208df6984a0dd4c360d9ece47e9efc823419333d"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.19.8755fe51cbd0feb281f85f4a4c18a40f1a30d98480c1b3d18ba1fa54a30ce705"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.20.c5f95da618d92fca54d233363f6d89cecfdca389b8dc331d4ea39d1a24ab78b1"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.21.634cc7d85fa5cb3190c58ff3c821a582c71fd4dcbce18e2560e9f83a92d9f2d1"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.22.fdb8c5e87e2680adde2c5903b892b5e979bc4e7ec1aa7274113efd6048614b87"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.23.d5e52872f000c57a7b03cb7306f18641d3498a0943aedce2d9d471973ef50ce1"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.24.4d0ced42119b047b4e2cc5d01cf3f39f1126969c3e0c9b15c09259fd3584446d"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.25.517b8eda4a7a0de9ba6b603a93d1fc1e3b75d943e308fd28cc04d6e4ab5a5487"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.26.2359ce7475a218e1c346e24caf8dc748636fca4dbaba2c2a40813457ee88b949"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.27.438a3e6e4ab4456ba5251d539c449b03d20022a8446729d549e9d0174d497194"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.28.325b0142d18e1b77bb1a7eb694bbc1c7a30391bda91bf25f3e32dd47284f6978"},
+				{OrderRef: "131daac9-16c6-4618-beb0-365768f37288", URI: "bankid:///?autostarttoken=7c40b5c9-fa74-49cf-b98c-bfe651f9a7c6\u0026redirect=null", QR: "bankid.67df3917-fa0d-44e5-b327-edcc928297f8.29.26049f2bc12d5b43ebe8bf701e7725abf015d2d8347aa04c924b5793ee4a196c"},
+			},
+		},
+	} {
+		t.Run(tt.name, testAuthSignV3(tt, e.NewContext))
+	}
+}
+
+func testAuthSignV3(tt authSignTestV3, newContext newContextFn) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		bodyData, err := json.Marshal(tt.request)
+		if err != nil {
+			t.Fatalf("ERROR: Failed to marshal request: %v", err)
+		}
+
+		u, err := url.Parse("http://test.local/api/someurl")
+		if err != nil {
+			t.Fatalf("ERROR: Failed to parse URL: %v", err)
+		}
+
+		if tt.params != nil {
+			u.RawQuery = tt.params.Encode()
+		}
+
+		req := httptest.NewRequest("", u.String(), bytes.NewReader(bodyData))
+		res := httptest.NewRecorder()
+		ctx := newContext(req, res)
+
+		echoHandler := authSignV3(tt.authSign(t), time.Millisecond, tt.encoder)
+		err = echoHandler(ctx)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		response := res.Result()
+		defer func() { _ = response.Body.Close() }()
+		if response.StatusCode != tt.wantHTTPStatus {
+			t.Errorf("ERROR: got HTTP status code: %d, want: %d\n", response.StatusCode, tt.wantHTTPStatus)
+		}
+
+		tt.testDecoder(t, req.Context(), response.Body, tt)
+	}
+}
+
+func ndjsonCheckV3(t *testing.T, ctx context.Context, body io.ReadCloser, tt authSignTestV3) {
+	responseChan := ndjson.NewReader[api.BankIdV6AuthSignResponseV3](ctx, body)
+	var cnt int
+	for res := range responseChan {
+		//t.Logf("got response: %v", res)
+		if cnt < len(tt.wantResponses) && !reflect.DeepEqual(res, tt.wantResponses[cnt]) {
+			t.Errorf(" got event: %v\nwant event: %v", res, tt.wantResponses[cnt])
+		}
+		cnt++
+	}
+	if cnt != len(tt.wantResponses) {
+		t.Errorf("got %d events, want %d", cnt, len(tt.wantEvents))
+	}
+}
+
+func sseCheckV3(t *testing.T, ctx context.Context, body io.ReadCloser, tt authSignTestV3) {
+	events := sse.NewReader(ctx, body)
+	var cnt int
+	for e := range events {
+		// t.Logf("%v: got event: %v", time.Since(start), e)
+		if cnt < len(tt.wantEvents) && !reflect.DeepEqual(e, tt.wantEvents[cnt]) {
+			t.Errorf(" got event: %v\nwant event: %v", e, tt.wantEvents[cnt])
+		}
+		cnt++
+	}
+	if cnt != len(tt.wantEvents) {
+		t.Errorf("got %d events, want %d", cnt, len(tt.wantEvents))
+	}
 }

--- a/stream/ndjson/writer.go
+++ b/stream/ndjson/writer.go
@@ -41,7 +41,7 @@ func NewEncoder(w http.ResponseWriter) (stream.Encoder, error) {
 	return enc.SendJSON, nil
 }
 
-func (w *Writer) SendJSON(_ string, data any) error {
+func (w *Writer) SendJSON(_, _ string, data any) error {
 	if data == nil {
 		return nil
 	}

--- a/stream/ndjson/writer_test.go
+++ b/stream/ndjson/writer_test.go
@@ -72,7 +72,7 @@ func TestWriter_SendEvent(t *testing.T) {
 				t.Fatalf("Failed to create new writer: %v", err)
 			}
 
-			err = w.SendJSON("", tt.data)
+			err = w.SendJSON("", "", tt.data)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("SendJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/stream/sse/writer.go
+++ b/stream/sse/writer.go
@@ -105,10 +105,10 @@ func (w *Writer) SendEvent(event, data, id, retry string) error {
 	return nil
 }
 
-func (w *Writer) SendJSON(event string, data any) error {
+func (w *Writer) SendJSON(id, event string, data any) error {
 	b, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
-	return w.SendEvent(event, string(b), "", "")
+	return w.SendEvent(event, string(b), id, "")
 }

--- a/stream/sse/writer.go
+++ b/stream/sse/writer.go
@@ -59,7 +59,7 @@ func writeField(buf *bytes.Buffer, field, data string) {
 	hasLineBreaks := strings.ContainsAny(data, "\n\r")
 	if !hasLineBreaks {
 		buf.WriteString(field)
-		buf.WriteString(":")
+		buf.WriteString(": ")
 		buf.WriteString(data)
 		buf.WriteString("\n")
 		return

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -4,5 +4,5 @@ type (
 	Writer interface {
 		SendJSON(string, string, any) error
 	}
-	Encoder func(string, string, any) error
+	Encoder func(id string, event string, data any) error
 )

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -2,7 +2,7 @@ package stream
 
 type (
 	Writer interface {
-		SendJSON(string, any) error
+		SendJSON(string, string, any) error
 	}
-	Encoder func(string, any) error
+	Encoder func(string, string, any) error
 )

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -87,7 +87,7 @@ func InitApplication(bankIDV6URL string) (*echo.Echo, error) {
 
 	client := &http.Client{}
 
-	twoferBankIDAPI := bankid.NewAPI(client, bankIDV6URL)
+	twoferBankIDAPI := bankid.NewAPI(client, bankIDV6URL, time.Second)
 	httpserve.RegisterBankIDServer(e, twoferBankIDAPI, nil)
 
 	return e, nil


### PR DESCRIPTION
A completed or failed order can only be collected a single time, and when
calling `collect` from the auth or sign endpoints, there is a small risk that
 it will collect the completed/failed orderRef.