### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/depot_license_generation.yml
+++ b/.github/workflows/depot_license_generation.yml
@@ -12,6 +12,8 @@ on:
       - '!**/node_modules/**'
 jobs:
   license_check:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/modfin/twofer/security/code-scanning/1](https://github.com/modfin/twofer/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block for the job `license_check` within the workflow. As this job needs to push changes to the repository using the GITHUB_TOKEN (which is used by `EndBug/add-and-commit`), it specifically requires `contents: write` permission. Setting this permission at the job-level limits the scope as much as possible—other jobs could have less access, if present. The fix involves editing `.github/workflows/depot_license_generation.yml`, adding:

```yaml
permissions:
  contents: write
```

just beneath the `license_check:` job definition and before `runs-on:`. No other changes, imports, or definitions are needed outside this YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
